### PR TITLE
Quick fix to allow nginx to be installed before another app

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -2,6 +2,7 @@
 
 set -e
 
+mkdir -p "$1/bin/"
 cp bin/nginx "$1/bin/"
 echo '-----> nginx-buildpack: Installed NGINX 1.4.1 to app/bin'
 cp bin/start-nginx "$1/bin/"

--- a/readme.md
+++ b/readme.md
@@ -69,8 +69,8 @@ Here are 2 setup examples. One example for a new app, another for an existing ap
 Update Buildpacks
 ```bash
 $ heroku config:set BUILDPACK_URL=https://github.com/ddollar/heroku-buildpack-multi.git
-$ echo 'https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz' >> .buildpacks
 $ echo 'https://codon-buildpacks.s3.amazonaws.com/buildpacks/ryandotsmith/nginx-buildpack.tgz' >> .buildpacks
+$ echo 'https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz' >> .buildpacks
 $ git add .buildpacks
 $ git commit -m 'Add multi-buildpack'
 ```


### PR DESCRIPTION
I think the nginx buildpack should run before any other buildpack, since [heroku-buildpack-multi](https://github.com/ddollar/heroku-buildpack-multi) outputs the result of the last buildpack to run (as far as I can tell).  As such, it looks like we lose some of the configured process types; `heroku run rake` for example won't work unless the version of ruby on the server happens to match the version expect by your app.  It should be `bundle exec rake`, which gets setup by [heroku-buildpack-ruby](https://github.com/heroku/heroku-buildpack-ruby) (but only if it's the last buildpack to run).
