### PR TITLE
provide start-nginx with -w and -f options

### DIFF
--- a/bin/start-nginx
+++ b/bin/start-nginx
@@ -8,12 +8,11 @@ mkfifo $psmgr
 erb config/nginx.conf.erb > config/nginx.conf
 
 n=1
-while getopts :wf: option ${@:1:4}
+while getopts :f option ${@:1:2}
 do
         case "${option}"
         in
-                w) WAIT=$OPTIND; n=$((n+1));;
-                f) FILE=$OPTARG; n=$((n+2));;
+                f) FORCE=$OPTIND; n=$((n+1));;
         esac
 done
 
@@ -38,12 +37,9 @@ done
 	echo 'app' >$psmgr
 ) &
 
-if [[ ! -z "$WAIT" ]]
+if [[ -z "$FORCE" ]]
 then
-	if [[ -z "$FILE" ]]
-	then
-		FILE="/tmp/app-initialized"
-	fi
+	FILE="/tmp/app-initialized"
 
 	#We block on app-initialized so that when NGINX binds to $PORT
 	#are app is ready for traffic.

--- a/bin/start-nginx
+++ b/bin/start-nginx
@@ -7,6 +7,16 @@ mkfifo $psmgr
 #Evaluate config to get $PORT
 erb config/nginx.conf.erb > config/nginx.conf
 
+n=1
+while getopts :wf: option ${@:1:4}
+do
+        case "${option}"
+        in
+                w) WAIT=$OPTIND; n=$((n+1));;
+                f) FILE=$OPTARG; n=$((n+2));;
+        esac
+done
+
 #Start log redirection.
 (
 	#Initialize log directory.
@@ -22,18 +32,28 @@ erb config/nginx.conf.erb > config/nginx.conf
 (
 	#Take the command passed to this bin and start it.
 	#E.g. bin/start-nginx bundle exec unicorn -c config/unicorn.rb
-	echo "buildpack=nginx at=start-app cmd=$@"
-	"$@"
+        COMMAND=${@:$n}
+	echo "buildpack=nginx at=start-app cmd=$COMMAND"
+	"$COMMAND"
 	echo 'app' >$psmgr
 ) &
-#We block on app-initialized so that when NGINX binds to $PORT
-#are app is ready for traffic.
-while [[ ! -f /tmp/app-initialized ]]
-do
-	echo 'buildpack=nginx at=app-initialization'
-	sleep 1
-done
-echo 'buildpack=nginx at=app-initialized'
+
+if [[ ! -z "$WAIT" ]]
+then
+	if [[ -z "$FILE" ]]
+	then
+		FILE="/tmp/app-initialized"
+	fi
+
+	#We block on app-initialized so that when NGINX binds to $PORT
+	#are app is ready for traffic.
+	while [[ ! -f "$FILE" ]]
+	do
+		echo 'buildpack=nginx at=app-initialization'
+		sleep 1
+	done
+	echo 'buildpack=nginx at=app-initialized'
+fi
 
 #Start NGINX
 (


### PR DESCRIPTION
-w forces start-nginx to wait for a file to appear before starting nginx.
-f [filename] specifies what file to wait for (default: /tmp/app-initialized).
