### PR TITLE
Fix `bundle exec unicorn -c config/unicorn.rb: No such file or directory`

### DIFF
--- a/bin/start-nginx
+++ b/bin/start-nginx
@@ -33,7 +33,7 @@ done
 	#E.g. bin/start-nginx bundle exec unicorn -c config/unicorn.rb
         COMMAND=${@:$n}
 	echo "buildpack=nginx at=start-app cmd=$COMMAND"
-	"$COMMAND"
+	$COMMAND
 	echo 'app' >$psmgr
 ) &
 


### PR DESCRIPTION
As reported by and @ilove8 @fabiokung, launching a Ruby app now shows the following error:

```
bin/start-nginx: line 36: bundle exec unicorn -c config/unicorn.rb: No such file or directory
```

To fix this, @fabiokung [suggested](https://github.com/ryandotsmith/nginx-buildpack/pull/6/files#r4828674) removing the quotes around `"$COMMAND"` on line 36 of `bin/start-nginx`, which solves the problem

For reference, this is my Procfile:

```
web: bin/start-nginx bundle exec unicorn -c config/unicorn.rb
```
