### PR TITLE
Updated nginx binary to 1.5.2 (with rewrite_module)

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,7 +4,8 @@ set -e
 
 mkdir -p "$1/bin/"
 cp bin/nginx "$1/bin/"
-echo '-----> nginx-buildpack: Installed NGINX 1.4.1 to app/bin'
+nginx_version=$(./bin/nginx -V 2>&1 | head -1 | awk '{ print $NF }')
+echo "-----> nginx-buildpack: Installed ${nginx_version} to app/bin"
 cp bin/start-nginx "$1/bin/"
 echo '-----> nginx-buildpack: Added start-nginx to app/bin'
 

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Some application servers (e.g. Ruby's Unicorn) halt progress when dealing with n
 ## Versions
 
 * Buildpack Version: 0.4
-* NGINX Version: 1.4.1
+* NGINX Version: 1.5.2
 
 ## Requirements
 


### PR DESCRIPTION
People using the buildpack are still getting the old nginx version without rewrite_module.

This pull request updates the binary, which was built using `scripts/build_nginx.sh`.

In the future, would it be cleaner to upload the build to S3 and have `bin/compile` download and extract the binary?
