### PR TITLE
Serve static assets directly

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -33,7 +33,13 @@ http {
 		server_name _;
 		keepalive_timeout 5;
 
+		root /app/public;
+
 		location / {
+			try_files $uri @proxy;
+		}
+
+		location @proxy {
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 			proxy_set_header Host $http_host;
 			proxy_redirect off;


### PR DESCRIPTION
This fix forces nginx first to try serving files itself without passing request to the application server.
