### PR TITLE
Added NGINX_WORKERS configuration

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -1,6 +1,6 @@
 daemon off;
-#Heroku dynos have 4 cores.
-worker_processes 4;
+#Heroku dynos have at least 4 cores.
+worker_processes <%= ENV['NGINX_WORKERS'] || 4 %>;
 
 events {
 	use epoll;

--- a/readme.md
+++ b/readme.md
@@ -52,9 +52,20 @@ $ cat Procfile
 web: bin/start-nginx bundle exec unicorn -c config/unicorn.rb
 ```
 
+### Setting the Worker Processes
+
+You can configure NGINX's `worker_processes` directive via the
+`NGINX_WORKERS` environment variable.
+
+For example, to set your `NGINX_WORKERS` to 8 on a PX dyno:
+
+```bash
+$ heroku config:set NGINX_WORKERS=8
+```
+
 ### Customizable NGINX Config
 
-You can provide your own NGINX config by creating a file named `nginx.conf.erb` in the config direcotry of your app. Start by copying the buildpack's [default config file](https://github.com/ryandotsmith/nginx-buildpack/blob/master/config/nginx.conf.erb).
+You can provide your own NGINX config by creating a file named `nginx.conf.erb` in the config directory of your app. Start by copying the buildpack's [default config file](https://github.com/ryandotsmith/nginx-buildpack/blob/master/config/nginx.conf.erb).
 
 ### Customizable NGINX Compile Options
 


### PR DESCRIPTION
I wanted to add a NGINX_WORKERS environment variable in the case of PX dynos. I understand that people can provide their own nginx.conf, but I think adding the env variable and documentation around it will  make people more aware that in the PX dynos, they should boost it to 8 workers.

P.S. Love the nginx-buildpack!
