### PR TITLE
Fix directory typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ web: bin/start-nginx bundle exec unicorn -c config/unicorn.rb
 
 ### Customizable NGINX Config
 
-You can provide your own NGINX config by creating a file named `nginx.conf.erb` in the config direcotry of your app. Start by copying the buildpack's [default config file](https://github.com/ryandotsmith/nginx-buildpack/blob/master/config/nginx.conf.erb).
+You can provide your own NGINX config by creating a file named `nginx.conf.erb` in the config directory of your app. Start by copying the buildpack's [default config file](https://github.com/ryandotsmith/nginx-buildpack/blob/master/config/nginx.conf.erb).
 
 ### Customizable NGINX Compile Options
 


### PR DESCRIPTION
The README had a typo.
