### PR TITLE
Don't show server_tokens

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -13,6 +13,8 @@ http {
         gzip_comp_level 2;
         gzip_min_length 512;
 
+	server_tokens off;
+
 	log_format l2met 'measure#nginx.service=$request_time request_id=$http_x_request_id';
 	access_log logs/nginx/access.log l2met;
 	error_log logs/nginx/error.log;


### PR DESCRIPTION
Showing server tokens reveals the nginx version number to would-be attackers. The version number is an easy way to figure out security exploits.
