### PR TITLE
Handle the case when we don't want of an app server

### DIFF
--- a/bin/start-nginx
+++ b/bin/start-nginx
@@ -8,7 +8,7 @@ mkfifo $psmgr
 erb config/nginx.conf.erb > config/nginx.conf
 
 n=1
-while getopts :f:n option "${@:1:3}"
+while getopts :fn option "${@:1:2}"
 do
         case "${option}"
         in

--- a/bin/start-nginx
+++ b/bin/start-nginx
@@ -8,11 +8,12 @@ mkfifo $psmgr
 erb config/nginx.conf.erb > config/nginx.conf
 
 n=1
-while getopts :f option ${@:1:2}
+while getopts :f:n option "${@:1:3}"
 do
         case "${option}"
         in
                 f) FORCE=$OPTIND; n=$((n+1));;
+                n) NO_SERVER=$OPTIND; n=$((n+1));;
         esac
 done
 
@@ -28,15 +29,20 @@ echo 'buildpack=nginx at=logs-initialized'
 	echo 'logs' >$psmgr
 ) &
 
+if [[ -z "$NO_SERVER" ]]
+then
+
 #Start App Server
 (
 	#Take the command passed to this bin and start it.
 	#E.g. bin/start-nginx bundle exec unicorn -c config/unicorn.rb
-        COMMAND=${@:$n}
+        COMMAND=${*:$n}
 	echo "buildpack=nginx at=start-app cmd=$COMMAND"
 	$COMMAND
 	echo 'app' >$psmgr
 ) &
+
+fi
 
 if [[ -z "$FORCE" ]]
 then


### PR DESCRIPTION
Currently, this NGINX buildpack suppose that we always want to use an app server.

Here is another option to disable the app server so that you can run NGINX on Heroku just for static files (useful when you have a React frontend and want to serve the static assets built by Webpack after the build pass of Node.js buildpack).

What do you think? I can, of course, rebase if needed.

I edited two parts of the script which were better according to [ShellCheck](http://www.shellcheck.net/)
